### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/890/434/941/890434941.geojson
+++ b/data/890/434/941/890434941.geojson
@@ -312,6 +312,9 @@
     },
     "wof:country":"GP",
     "wof:created":1469052046,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d5a914d8ee42d5f2f2a52cc8c3b3f98",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         }
     ],
     "wof:id":890434941,
-    "wof:lastmodified":1566640115,
+    "wof:lastmodified":1582358677,
     "wof:name":"Saint-Fran\u00e7ois",
     "wof:parent_id":85671209,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.