### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/790/5/1141907905.geojson
+++ b/data/114/190/790/5/1141907905.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-61.532998903,16.2414750356,-61.532998903,16.2414750356",
+    "geom:bbox":"-61.532999,16.241475,-61.532999,16.241475",
     "geom:latitude":16.241475,
     "geom:longitude":-61.532999,
     "iso:country":"GP",
@@ -53,6 +53,9 @@
     ],
     "name:ces_x_preferred":[
         "Pointe-\u00e0-Pitre"
+    ],
+    "name:che_x_preferred":[
+        "\u041f\u0443\u044d\u043d\u0442-\u0430-\u041f\u0438\u0442\u0433\u04c0"
     ],
     "name:cos_x_preferred":[
         "Pointe-\u00e0-Pitre"
@@ -113,6 +116,9 @@
     ],
     "name:gsw_x_preferred":[
         "Pointe-\u00e0-Pitre"
+    ],
+    "name:hat_x_preferred":[
+        "Lapwent"
     ],
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05d0\u05e0\u05d8-\u05d0-\u05e4\u05d9\u05d8\u05e8"
@@ -179,6 +185,9 @@
     ],
     "name:lit_x_preferred":[
         "Puant a Pitras"
+    ],
+    "name:lld_x_preferred":[
+        "Pointe-\u00e0-Pitre"
     ],
     "name:ltz_x_preferred":[
         "Pointe-\u00e0-Pitre"
@@ -269,6 +278,12 @@
     ],
     "name:swe_x_preferred":[
         "Pointe-\u00e0-Pitre"
+    ],
+    "name:tat_x_preferred":[
+        "\u041f\u0443\u044d\u043d\u0442-\u0430-\u041f\u0438\u0442\u0440"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e1b\u0e27\u0e07\u0e15\u0e32\u0e1b\u0e34\u0e17\u0e23\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Pointe-\u00e0-Pitre"
@@ -414,7 +429,7 @@
     },
     "wof:country":"GP",
     "wof:created":1499130786,
-    "wof:geomhash":"fc0ae91c028303b1afb4f82b41fd56c4",
+    "wof:geomhash":"5bb6e99334fb6e862275ac8918dbd6d9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -425,7 +440,7 @@
         }
     ],
     "wof:id":1141907905,
-    "wof:lastmodified":1566640170,
+    "wof:lastmodified":1690922105,
     "wof:name":"Pointe-a-Pitre",
     "wof:parent_id":85671209,
     "wof:placetype":"locality",
@@ -435,10 +450,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -61.53299890302799,
-    16.2414750355631,
-    -61.53299890302799,
-    16.2414750355631
+    -61.532999,
+    16.241475,
+    -61.532999,
+    16.241475
 ],
-  "geometry": {"coordinates":[-61.53299890302799,16.2414750355631],"type":"Point"}
+  "geometry": {"coordinates":[-61.532999,16.241475],"type":"Point"}
 }

--- a/data/114/190/790/7/1141907907.geojson
+++ b/data/114/190/790/7/1141907907.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-61.4399813249,16.2303904408,-61.4399813249,16.2303904408",
+    "geom:bbox":"-61.439981,16.23039,-61.439981,16.23039",
     "geom:latitude":16.23039,
     "geom:longitude":-61.439981,
     "iso:country":"GP",
@@ -27,6 +27,9 @@
     "name:arg_x_preferred":[
         "Basse-Terre"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0633 \u062a\u064a\u0631"
+    ],
     "name:ast_x_preferred":[
         "Basse-Terre"
     ],
@@ -41,6 +44,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0430\u0441\u0430-\u0422\u044d\u0440\u044d"
+    ],
+    "name:bel_x_variant":[
+        "\u0411\u0430\u0441-\u0422\u044d\u0440"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b8\u09c7-\u099f\u09cd\u09af\u09be\u09b0\u09c0"
@@ -65,6 +71,9 @@
     ],
     "name:ces_x_preferred":[
         "Basse-Terre"
+    ],
+    "name:che_x_preferred":[
+        "\u0411\u0430\u0441-\u0422\u0435\u0433\u04c0"
     ],
     "name:cos_x_preferred":[
         "Basse-Terre"
@@ -110,6 +119,9 @@
     ],
     "name:frp_x_preferred":[
         "B\u00e2ssa-T\u00e8rra"
+    ],
+    "name:frr_x_preferred":[
+        "Basse-Terre"
     ],
     "name:fur_x_preferred":[
         "Basse-Terre"
@@ -195,6 +207,9 @@
     "name:lat_x_preferred":[
         "Basse-Terre"
     ],
+    "name:lat_x_variant":[
+        "Ima Tellus"
+    ],
     "name:lav_x_preferred":[
         "Bast\u0113ra"
     ],
@@ -206,6 +221,9 @@
     ],
     "name:lit_x_preferred":[
         "Bas Teras"
+    ],
+    "name:lld_x_preferred":[
+        "Basse-Terre"
     ],
     "name:ltz_x_preferred":[
         "Basse-Terre"
@@ -227,6 +245,9 @@
     ],
     "name:msa_x_preferred":[
         "Basse-Terre"
+    ],
+    "name:nah_x_preferred":[
+        "Basseterre"
     ],
     "name:nan_x_preferred":[
         "Basse-Terre"
@@ -321,6 +342,9 @@
     "name:tam_x_preferred":[
         "\u0baa\u0bbe\u0bb8\u0bcd\u0ba4\u0bc6\u0bb0\u0bcd"
     ],
+    "name:tat_x_preferred":[
+        "\u0411\u0430\u0441-\u0422\u0435\u0440"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c3e\u0c38\u0c40-\u0c1f\u0c46\u0c30\u0c4d\u0c30\u0c40"
     ],
@@ -334,6 +358,9 @@
         "Bas-Ter"
     ],
     "name:tur_x_preferred":[
+        "Basse-Terre"
+    ],
+    "name:twi_x_preferred":[
         "Basse-Terre"
     ],
     "name:ukr_x_preferred":[
@@ -368,6 +395,9 @@
     ],
     "name:wol_x_preferred":[
         "Basse-Terre"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5df4\u65af\u7279\u5c14"
     ],
     "name:yor_x_preferred":[
         "Basse-Terre"
@@ -489,7 +519,7 @@
     },
     "wof:country":"GP",
     "wof:created":1499130786,
-    "wof:geomhash":"abcf0c2681667de12a6b991d32dbfc56",
+    "wof:geomhash":"d94f8f748801050e4913c5ed0f8cc42a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -500,7 +530,7 @@
         }
     ],
     "wof:id":1141907907,
-    "wof:lastmodified":1566640170,
+    "wof:lastmodified":1690922104,
     "wof:name":"Basse-terre",
     "wof:parent_id":85671209,
     "wof:placetype":"locality",
@@ -510,10 +540,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -61.43998132490259,
-    16.23039044083657,
-    -61.43998132490259,
-    16.23039044083657
+    -61.439981,
+    16.23039,
+    -61.439981,
+    16.23039
 ],
-  "geometry": {"coordinates":[-61.43998132490259,16.23039044083657],"type":"Point"}
+  "geometry": {"coordinates":[-61.439981,16.23039],"type":"Point"}
 }

--- a/data/890/418/559/890418559.geojson
+++ b/data/890/418/559/890418559.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Gourbeyre"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0631\u0628\u064a\u0631"
+    ],
     "name:ast_x_preferred":[
         "Gourbeyre"
     ],
@@ -52,6 +55,9 @@
     "name:ces_x_preferred":[
         "Gourbeyre"
     ],
+    "name:che_x_preferred":[
+        "\u0413\u0443\u0433\u04c0\u0431\u0435\u0433\u04c0"
+    ],
     "name:cos_x_preferred":[
         "Gourbeyre"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Gourbeyre"
+    ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03bf\u03c5\u03c1\u03bc\u03c0\u03ad\u03c1"
     ],
     "name:eng_x_preferred":[
         "Gourbeyre"
@@ -163,6 +172,9 @@
     "name:lit_x_preferred":[
         "Gourbeyre"
     ],
+    "name:lld_x_preferred":[
+        "Gourbeyre"
+    ],
     "name:ltz_x_preferred":[
         "Gourbeyre"
     ],
@@ -244,6 +256,9 @@
     "name:swe_x_preferred":[
         "Gourbeyre"
     ],
+    "name:tat_x_preferred":[
+        "\u0413\u0443\u0440\u0431\u0435\u0440"
+    ],
     "name:tur_x_preferred":[
         "Gourbeyre"
     ],
@@ -273,6 +288,9 @@
     ],
     "name:wol_x_preferred":[
         "Gourbeyre"
+    ],
+    "name:zho_x_preferred":[
+        "\u53e4\u8d1d\u5c14"
     ],
     "name:zul_x_preferred":[
         "Gourbeyre"
@@ -309,7 +327,7 @@
         }
     ],
     "wof:id":890418559,
-    "wof:lastmodified":1566640114,
+    "wof:lastmodified":1690922101,
     "wof:name":"Gourbeyre",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/418/561/890418561.geojson
+++ b/data/890/418/561/890418561.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Deshaies"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0633\u064a\u0647"
+    ],
     "name:ast_x_preferred":[
         "Deshaies"
     ],
@@ -52,6 +55,9 @@
     "name:ces_x_preferred":[
         "Deshaies"
     ],
+    "name:che_x_preferred":[
+        "\u0414\u0435\u0441\u0435"
+    ],
     "name:cos_x_preferred":[
         "Deshaies"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Deshaies"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03b5\u03b1\u03af"
     ],
     "name:eng_x_preferred":[
         "Deshaies"
@@ -160,6 +169,9 @@
     "name:lit_x_preferred":[
         "Deshaies"
     ],
+    "name:lld_x_preferred":[
+        "Deshaies"
+    ],
     "name:ltz_x_preferred":[
         "Deshaies"
     ],
@@ -244,6 +256,9 @@
     "name:swe_x_preferred":[
         "Deshaies"
     ],
+    "name:tat_x_preferred":[
+        "\u0414\u0435\u0441\u0435"
+    ],
     "name:tur_x_preferred":[
         "Deshaies"
     ],
@@ -309,7 +324,7 @@
         }
     ],
     "wof:id":890418561,
-    "wof:lastmodified":1566640114,
+    "wof:lastmodified":1690922101,
     "wof:name":"Deshaies",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/420/199/890420199.geojson
+++ b/data/890/420/199/890420199.geojson
@@ -31,6 +31,9 @@
     "name:ell_x_preferred":[
         "\u0394\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1 \u039c\u03c0\u03b1\u03c2-\u03a4\u03b5\u03c1"
     ],
+    "name:ell_x_variant":[
+        "\u03b4\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1 \u03c4\u03b7\u03c2 \u039c\u03c0\u03b1\u03c2-\u03a4\u03b5\u03c1"
+    ],
     "name:eng_x_preferred":[
         "Basse-Terre"
     ],
@@ -46,6 +49,9 @@
     "name:fra_x_preferred":[
         "Basse-Terre"
     ],
+    "name:gle_x_preferred":[
+        "Arrondissement Basse-Terre"
+    ],
     "name:ind_x_preferred":[
         "Arondisemen Basse-Terre"
     ],
@@ -57,6 +63,9 @@
     ],
     "name:nld_x_preferred":[
         "Arrondissement Basse-Terre"
+    ],
+    "name:nld_x_variant":[
+        "arrondissement Basse-Terre"
     ],
     "name:pol_x_preferred":[
         "Okr\u0119g Basse-Terre"
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":890420199,
-    "wof:lastmodified":1566640114,
+    "wof:lastmodified":1690922100,
     "wof:name":"Arrondissement de la Basse-Terre",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/422/909/890422909.geojson
+++ b/data/890/422/909/890422909.geojson
@@ -55,6 +55,9 @@
     "name:ces_x_preferred":[
         "Pointe-\u00e0-Pitre"
     ],
+    "name:che_x_preferred":[
+        "\u041f\u0443\u044d\u043d\u0442-\u0430-\u041f\u0438\u0442\u0433\u04c0"
+    ],
     "name:cos_x_preferred":[
         "Pointe-\u00e0-Pitre"
     ],
@@ -118,6 +121,9 @@
     "name:gsw_x_preferred":[
         "Pointe-\u00e0-Pitre"
     ],
+    "name:hat_x_preferred":[
+        "Lapwent"
+    ],
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05d0\u05e0\u05d8-\u05d0-\u05e4\u05d9\u05d8\u05e8"
     ],
@@ -176,6 +182,9 @@
         "Pointe-\u00e0-Pitre"
     ],
     "name:lim_x_preferred":[
+        "Pointe-\u00e0-Pitre"
+    ],
+    "name:lld_x_preferred":[
         "Pointe-\u00e0-Pitre"
     ],
     "name:ltz_x_preferred":[
@@ -265,6 +274,12 @@
     "name:swe_x_preferred":[
         "Pointe-\u00e0-Pitre"
     ],
+    "name:tat_x_preferred":[
+        "\u041f\u0443\u044d\u043d\u0442-\u0430-\u041f\u0438\u0442\u0440"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e1b\u0e27\u0e07\u0e15\u0e32\u0e1b\u0e34\u0e17\u0e23\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Pointe-\u00e0-Pitre"
     ],
@@ -333,7 +348,7 @@
         }
     ],
     "wof:id":890422909,
-    "wof:lastmodified":1566640112,
+    "wof:lastmodified":1690922097,
     "wof:name":"Pointe-\u00e0-Pitre",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/429/583/890429583.geojson
+++ b/data/890/429/583/890429583.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Petit-Canal"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u0649 \u0643\u0627\u0646\u0627\u0644"
+    ],
     "name:ast_x_preferred":[
         "Petit-Canal"
     ],
@@ -52,6 +55,9 @@
     "name:ces_x_preferred":[
         "Petit-Canal"
     ],
+    "name:che_x_preferred":[
+        "\u041f\u0435\u0442\u0438-\u041a\u0430\u043d\u0430\u043b"
+    ],
     "name:cos_x_preferred":[
         "Petit-Canal"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Petit-Canal"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b5\u03c4\u03af-\u039a\u03b1\u03bd\u03ac\u03bb"
     ],
     "name:eng_x_preferred":[
         "Petit-Canal"
@@ -160,6 +169,9 @@
     "name:lit_x_preferred":[
         "Petit-Canal"
     ],
+    "name:lld_x_preferred":[
+        "Petit-Canal"
+    ],
     "name:ltz_x_preferred":[
         "Petit-Canal"
     ],
@@ -241,6 +253,9 @@
     "name:swe_x_preferred":[
         "Petit-Canal"
     ],
+    "name:tat_x_preferred":[
+        "\u041f\u0442\u0438-\u041a\u0430\u043d\u0430\u043b"
+    ],
     "name:tur_x_preferred":[
         "Petit-Canal"
     ],
@@ -273,6 +288,9 @@
     ],
     "name:wol_x_preferred":[
         "Petit-Canal"
+    ],
+    "name:zho_x_preferred":[
+        "\u73c0\u8482\u5361\u7eb3\u52d2"
     ],
     "name:zul_x_preferred":[
         "Petit-Canal"
@@ -310,7 +328,7 @@
         }
     ],
     "wof:id":890429583,
-    "wof:lastmodified":1566640113,
+    "wof:lastmodified":1690922100,
     "wof:name":"Petit-Canal",
     "wof:parent_id":85671209,
     "wof:placetype":"locality",

--- a/data/890/434/939/890434939.geojson
+++ b/data/890/434/939/890434939.geojson
@@ -40,6 +40,9 @@
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0422\u044d\u0440-\u0434\u044d-\u0411\u0430\u0441"
     ],
+    "name:bel_x_variant":[
+        "\u0422\u044d\u0440-\u0434\u044d-\u0411\u0430\u0441"
+    ],
     "name:bre_x_preferred":[
         "Terre-de-Bas"
     ],
@@ -55,6 +58,9 @@
     "name:ces_x_preferred":[
         "Terre-de-Bas"
     ],
+    "name:che_x_preferred":[
+        "\u0422\u0435\u0433\u04c0-\u0434\u0435-\u0411\u0430"
+    ],
     "name:cos_x_preferred":[
         "Terre-de-Bas"
     ],
@@ -66,6 +72,9 @@
     ],
     "name:deu_x_preferred":[
         "Terre-de-Bas"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b5\u03c1-\u03bd\u03c4\u03b5-\u039c\u03c0\u03b1"
     ],
     "name:eng_x_preferred":[
         "Terre-de-Bas"
@@ -142,6 +151,9 @@
     "name:jpn_x_preferred":[
         "\u30c6\u30fc\u30eb\u30fb\u30c9\u30fb\u30d0\u5cf6"
     ],
+    "name:jpn_x_variant":[
+        "\u30c6\u30fc\u30eb\uff1d\u30c9\uff1d\u30d0"
+    ],
     "name:kab_x_preferred":[
         "Terre-de-Bas"
     ],
@@ -164,6 +176,9 @@
         "Terre-de-Bas"
     ],
     "name:lit_x_preferred":[
+        "Terre-de-Bas"
+    ],
+    "name:lld_x_preferred":[
         "Terre-de-Bas"
     ],
     "name:ltz_x_preferred":[
@@ -247,6 +262,9 @@
     "name:swe_x_preferred":[
         "Terre-de-Bas"
     ],
+    "name:tat_x_preferred":[
+        "\u0422\u0435\u0440-\u0434\u0435-\u0411\u0430"
+    ],
     "name:tur_x_preferred":[
         "Terre-de-Bas"
     ],
@@ -280,6 +298,9 @@
     "name:wol_x_preferred":[
         "Terre-de-Bas"
     ],
+    "name:zho_x_preferred":[
+        "\u7279\u5c14\u5fb7\u5df4"
+    ],
     "name:zul_x_preferred":[
         "Terre-de-Bas"
     ],
@@ -311,7 +332,7 @@
         }
     ],
     "wof:id":890434939,
-    "wof:lastmodified":1566640115,
+    "wof:lastmodified":1690922102,
     "wof:name":"Terre-de-Bas",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/941/890434941.geojson
+++ b/data/890/434/941/890434941.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646-\u0641\u0631\u0627\u0646\u0633\u0648\u0627"
     ],
+    "name:ara_x_variant":[
+        "\u0633\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u0648\u0627"
+    ],
     "name:arg_x_preferred":[
         "Saint-Fran\u00e7ois"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u0648\u0627"
     ],
     "name:ast_x_preferred":[
         "Saint-Fran\u00e7ois"
@@ -52,6 +58,9 @@
     "name:ces_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
+    "name:che_x_preferred":[
+        "\u0421\u0435\u043d-\u0424\u0433\u04c0\u0430\u043d\u0441\u0443\u0430"
+    ],
     "name:cos_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
@@ -63,6 +72,9 @@
     ],
     "name:deu_x_preferred":[
         "Saint-Fran\u00e7ois"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03b9\u03bd-\u03a6\u03c1\u03b1\u03bd\u03c3\u03bf\u03c5\u03ac"
     ],
     "name:eng_x_preferred":[
         "Saint-Fran\u00e7ois"
@@ -148,6 +160,9 @@
     "name:lat_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
+    "name:lat_x_variant":[
+        "Sanctus Franciscus"
+    ],
     "name:lav_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
@@ -158,6 +173,9 @@
         "Saint-Fran\u00e7ois"
     ],
     "name:lit_x_preferred":[
+        "Saint-Fran\u00e7ois"
+    ],
+    "name:lld_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
     "name:ltz_x_preferred":[
@@ -244,6 +262,9 @@
     "name:swe_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
+    "name:tat_x_preferred":[
+        "\u0421\u0435\u043d-\u0424\u0440\u0430\u043d\u0441\u0443\u0430"
+    ],
     "name:tur_x_preferred":[
         "Saint-Fran\u00e7ois"
     ],
@@ -279,6 +300,9 @@
     ],
     "name:wol_x_preferred":[
         "Saint-Fran\u00e7ois"
+    ],
+    "name:zho_x_preferred":[
+        "\u5723\u5f17\u6717\u7d22\u74e6"
     ],
     "name:zul_x_preferred":[
         "Saint-Fran\u00e7ois"
@@ -326,7 +350,7 @@
         }
     ],
     "wof:id":890434941,
-    "wof:lastmodified":1582358677,
+    "wof:lastmodified":1690922103,
     "wof:name":"Saint-Fran\u00e7ois",
     "wof:parent_id":85671209,
     "wof:placetype":"locality",

--- a/data/890/434/945/890434945.geojson
+++ b/data/890/434/945/890434945.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Basse-Terre"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0633 \u062a\u064a\u0631"
+    ],
     "name:ast_x_preferred":[
         "Basse-Terre"
     ],
@@ -44,7 +47,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0430\u0441-\u0422\u044d\u0440"
     ],
     "name:bel_x_variant":[
-        "\u0413\u043e\u0440\u0430\u0434 \u0411\u0430\u0441\u0430-\u0422\u044d\u0440\u044d"
+        "\u0413\u043e\u0440\u0430\u0434 \u0411\u0430\u0441\u0430-\u0422\u044d\u0440\u044d",
+        "\u0411\u0430\u0441-\u0422\u044d\u0440"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b8\u09c7-\u099f\u09cd\u09af\u09be\u09b0\u09c0"
@@ -69,6 +73,9 @@
     ],
     "name:ces_x_preferred":[
         "Basse-Terre"
+    ],
+    "name:che_x_preferred":[
+        "\u0411\u0430\u0441-\u0422\u0435\u0433\u04c0"
     ],
     "name:cos_x_preferred":[
         "Basse-Terre"
@@ -123,6 +130,9 @@
     ],
     "name:frp_x_preferred":[
         "B\u00e2ssa-T\u00e8rra"
+    ],
+    "name:frr_x_preferred":[
+        "Basse-Terre"
     ],
     "name:fur_x_preferred":[
         "Basse-Terre"
@@ -208,6 +218,9 @@
     "name:lat_x_preferred":[
         "Basse-Terre"
     ],
+    "name:lat_x_variant":[
+        "Ima Tellus"
+    ],
     "name:lav_x_preferred":[
         "Bast\u0113ra"
     ],
@@ -219,6 +232,9 @@
     ],
     "name:lit_x_preferred":[
         "Bas Teras"
+    ],
+    "name:lld_x_preferred":[
+        "Basse-Terre"
     ],
     "name:ltz_x_preferred":[
         "Basse-Terre"
@@ -240,6 +256,9 @@
     ],
     "name:msa_x_preferred":[
         "Basse-Terre"
+    ],
+    "name:nah_x_preferred":[
+        "Basseterre"
     ],
     "name:nan_x_preferred":[
         "Basse-Terre"
@@ -334,6 +353,9 @@
     "name:tam_x_preferred":[
         "\u0baa\u0bbe\u0bb8\u0bcd\u0ba4\u0bc6\u0bb0\u0bcd"
     ],
+    "name:tat_x_preferred":[
+        "\u0411\u0430\u0441-\u0422\u0435\u0440"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c3e\u0c38\u0c40-\u0c1f\u0c46\u0c30\u0c4d\u0c30\u0c40"
     ],
@@ -347,6 +369,9 @@
         "Bas-Ter"
     ],
     "name:tur_x_preferred":[
+        "Basse-Terre"
+    ],
+    "name:twi_x_preferred":[
         "Basse-Terre"
     ],
     "name:ukr_x_preferred":[
@@ -381,6 +406,9 @@
     ],
     "name:wol_x_preferred":[
         "Basse-Terre"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5df4\u65af\u7279\u5c14"
     ],
     "name:yor_x_preferred":[
         "Basse-Terre"
@@ -425,7 +453,7 @@
         }
     ],
     "wof:id":890434945,
-    "wof:lastmodified":1607390879,
+    "wof:lastmodified":1690922103,
     "wof:name":"Basse-Terre",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/437/321/890437321.geojson
+++ b/data/890/437/321/890437321.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Petit-Canal"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u0649 \u0643\u0627\u0646\u0627\u0644"
+    ],
     "name:ast_x_preferred":[
         "Petit-Canal"
     ],
@@ -52,6 +55,9 @@
     "name:ces_x_preferred":[
         "Petit-Canal"
     ],
+    "name:che_x_preferred":[
+        "\u041f\u0435\u0442\u0438-\u041a\u0430\u043d\u0430\u043b"
+    ],
     "name:cos_x_preferred":[
         "Petit-Canal"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Petit-Canal"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b5\u03c4\u03af-\u039a\u03b1\u03bd\u03ac\u03bb"
     ],
     "name:eng_x_preferred":[
         "Petit-Canal"
@@ -160,6 +169,9 @@
     "name:lit_x_preferred":[
         "Petit-Canal"
     ],
+    "name:lld_x_preferred":[
+        "Petit-Canal"
+    ],
     "name:ltz_x_preferred":[
         "Petit-Canal"
     ],
@@ -241,6 +253,9 @@
     "name:swe_x_preferred":[
         "Petit-Canal"
     ],
+    "name:tat_x_preferred":[
+        "\u041f\u0442\u0438-\u041a\u0430\u043d\u0430\u043b"
+    ],
     "name:tur_x_preferred":[
         "Petit-Canal"
     ],
@@ -270,6 +285,9 @@
     ],
     "name:wol_x_preferred":[
         "Petit-Canal"
+    ],
+    "name:zho_x_preferred":[
+        "\u73c0\u8482\u5361\u7eb3\u52d2"
     ],
     "name:zul_x_preferred":[
         "Petit-Canal"
@@ -306,7 +324,7 @@
         }
     ],
     "wof:id":890437321,
-    "wof:lastmodified":1566640112,
+    "wof:lastmodified":1690922099,
     "wof:name":"Petit-Canal",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/437/323/890437323.geojson
+++ b/data/890/437/323/890437323.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u064a-\u0628\u0648\u0631"
     ],
+    "name:ara_x_variant":[
+        "\u0628\u064a\u062a\u064a \u0628\u0648\u0631"
+    ],
     "name:arg_x_preferred":[
         "Petit-Bourg"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u0649 \u0628\u0648\u0631"
     ],
     "name:ast_x_preferred":[
         "Petit-Bourg"
@@ -55,6 +61,9 @@
     "name:ces_x_preferred":[
         "Petit-Bourg"
     ],
+    "name:che_x_preferred":[
+        "\u041f\u0435\u0442\u0438-\u0411\u0443\u0433\u04c0"
+    ],
     "name:cos_x_preferred":[
         "Petit-Bourg"
     ],
@@ -66,6 +75,9 @@
     ],
     "name:deu_x_preferred":[
         "Petit-Bourg"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b5\u03c4\u03af-\u039c\u03c0\u03bf\u03c5\u03c1"
     ],
     "name:eng_x_preferred":[
         "Petit-Bourg"
@@ -151,6 +163,9 @@
     "name:kon_x_preferred":[
         "Petit-Bourg"
     ],
+    "name:kor_x_preferred":[
+        "\ud504\ud2f0\ubd80\ub974"
+    ],
     "name:lat_x_preferred":[
         "Petit-Bourg"
     ],
@@ -164,6 +179,9 @@
         "Petit-Bourg"
     ],
     "name:lit_x_preferred":[
+        "Petit-Bourg"
+    ],
+    "name:lld_x_preferred":[
         "Petit-Bourg"
     ],
     "name:ltz_x_preferred":[
@@ -253,6 +271,9 @@
     "name:swe_x_preferred":[
         "Petit-Bourg"
     ],
+    "name:tat_x_preferred":[
+        "\u041f\u0442\u0438-\u0411\u0443\u0440"
+    ],
     "name:tur_x_preferred":[
         "Petit-Bourg"
     ],
@@ -282,6 +303,9 @@
     ],
     "name:wol_x_preferred":[
         "Petit-Bourg"
+    ],
+    "name:zho_x_preferred":[
+        "\u73c0\u8482\u5821"
     ],
     "name:zul_x_preferred":[
         "Petit-Bourg"
@@ -318,7 +342,7 @@
         }
     ],
     "wof:id":890437323,
-    "wof:lastmodified":1566640112,
+    "wof:lastmodified":1690922098,
     "wof:name":"Petit-Bourg",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/439/161/890439161.geojson
+++ b/data/890/439/161/890439161.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Les Abymes"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0632\u0627\u0628\u064a\u0645"
+    ],
     "name:ast_x_preferred":[
         "Les Abymes"
     ],
@@ -54,6 +57,12 @@
     ],
     "name:ces_x_preferred":[
         "Les Abymes"
+    ],
+    "name:che_x_preferred":[
+        "\u041b\u0435\u0437-\u0410\u0431\u0438\u043c"
+    ],
+    "name:chv_x_preferred":[
+        "\u041b\u0435\u0437-\u0410\u0431\u0438\u043c"
     ],
     "name:cos_x_preferred":[
         "Les Abymes"
@@ -124,6 +133,9 @@
     "name:hun_x_preferred":[
         "Les Abymes"
     ],
+    "name:hye_x_preferred":[
+        "\u053c\u0565\u0566 \u0531\u0562\u056b\u0574"
+    ],
     "name:ido_x_preferred":[
         "Les Abymes"
     ],
@@ -173,6 +185,9 @@
         "Les Abymes"
     ],
     "name:lit_x_preferred":[
+        "Les Abymes"
+    ],
+    "name:lld_x_preferred":[
         "Les Abymes"
     ],
     "name:ltz_x_preferred":[
@@ -241,6 +256,9 @@
     "name:rus_x_preferred":[
         "\u0410\u0431\u0438\u043c\u0435\u0441"
     ],
+    "name:rus_x_variant":[
+        "\u041b\u0435\u0437-\u0410\u0431\u0438\u043c"
+    ],
     "name:scn_x_preferred":[
         "Les Abymes"
     ],
@@ -256,11 +274,17 @@
     "name:srd_x_preferred":[
         "Les Abymes"
     ],
+    "name:srp_x_preferred":[
+        "\u041b\u0435\u0437 \u0410\u0431\u0438\u043c"
+    ],
     "name:swa_x_preferred":[
         "Les Abymes"
     ],
     "name:swe_x_preferred":[
         "Les Abymes"
+    ],
+    "name:tat_x_preferred":[
+        "\u041b\u0435\u0437-\u0410\u0431\u0438\u043c"
     ],
     "name:tur_x_preferred":[
         "Les Abymes"
@@ -294,6 +318,9 @@
     ],
     "name:zho_x_preferred":[
         "\u85a9\u840a\u6bd4\u6885"
+    ],
+    "name:zho_x_variant":[
+        "\u83b1\u8428\u6bd4\u59c6"
     ],
     "name:zul_x_preferred":[
         "Les Abymes"
@@ -330,7 +357,7 @@
         }
     ],
     "wof:id":890439161,
-    "wof:lastmodified":1566640112,
+    "wof:lastmodified":1690922097,
     "wof:name":"Les Abymes",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/439/163/890439163.geojson
+++ b/data/890/439/163/890439163.geojson
@@ -49,6 +49,9 @@
     "name:ces_x_preferred":[
         "Vieux-Habitants"
     ],
+    "name:che_x_preferred":[
+        "\u0412\u044c\u043e\u044c-\u0410\u0431\u0438\u0442\u0430\u043d"
+    ],
     "name:cos_x_preferred":[
         "Vieux-Habitants"
     ],
@@ -60,6 +63,9 @@
     ],
     "name:deu_x_preferred":[
         "Vieux-Habitants"
+    ],
+    "name:ell_x_preferred":[
+        "\u0392\u03b9\u03ad\u03b6-\u0391\u03bc\u03c0\u03b9\u03c4\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Vieux-Habitants"
@@ -157,6 +163,9 @@
     "name:lit_x_preferred":[
         "Vieux-Habitants"
     ],
+    "name:lld_x_preferred":[
+        "Vieux-Habitants"
+    ],
     "name:ltz_x_preferred":[
         "Vieux-Habitants"
     ],
@@ -238,6 +247,9 @@
     "name:swe_x_preferred":[
         "Vieux-Habitants"
     ],
+    "name:tat_x_preferred":[
+        "\u0412\u044c\u0451-\u0410\u0431\u0438\u0442\u0430\u043d"
+    ],
     "name:tur_x_preferred":[
         "Vieux-Habitants"
     ],
@@ -267,6 +279,9 @@
     ],
     "name:wol_x_preferred":[
         "Vieux-Habitants"
+    ],
+    "name:zho_x_preferred":[
+        "\u7ef4\u7ea6\u8428\u6bd4\u5510"
     ],
     "name:zul_x_preferred":[
         "Vieux-Habitants"
@@ -303,7 +318,7 @@
         }
     ],
     "wof:id":890439163,
-    "wof:lastmodified":1566640112,
+    "wof:lastmodified":1690922098,
     "wof:name":"Vieux-Habitants",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/440/921/890440921.geojson
+++ b/data/890/440/921/890440921.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Anse-Bertrand"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0646\u0633 \u0628\u0631\u062a\u0631\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Anse-Bertrand"
     ],
@@ -52,6 +55,9 @@
     "name:ces_x_preferred":[
         "Anse-Bertrand"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u043d\u0441-\u0411\u0435\u0433\u04c0\u0442\u0433\u04c0\u0430\u043d"
+    ],
     "name:cos_x_preferred":[
         "Anse-Bertrand"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Anse-Bertrand"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c2-\u039c\u03c0\u03b5\u03c1\u03c4\u03c1\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Anse-Bertrand"
@@ -78,6 +87,9 @@
     ],
     "name:fao_x_preferred":[
         "Anse-Bertrand"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0646\u0633\u0647-\u0628\u0631\u062a\u0631\u0627\u0646"
     ],
     "name:fin_x_preferred":[
         "Anse-Bertrand"
@@ -160,6 +172,9 @@
     "name:lit_x_preferred":[
         "Anse-Bertrand"
     ],
+    "name:lld_x_preferred":[
+        "Anse-Bertrand"
+    ],
     "name:ltz_x_preferred":[
         "Anse-Bertrand"
     ],
@@ -220,6 +235,9 @@
     "name:ron_x_preferred":[
         "Anse-Bertrand"
     ],
+    "name:rus_x_preferred":[
+        "\u0410\u043d\u0441-\u0411\u0435\u0440\u0442\u0440\u0430\u043d"
+    ],
     "name:scn_x_preferred":[
         "Anse-Bertrand"
     ],
@@ -240,6 +258,9 @@
     ],
     "name:swe_x_preferred":[
         "Anse-Bertrand"
+    ],
+    "name:tat_x_preferred":[
+        "\u0410\u043d\u0441-\u0411\u0435\u0440\u0442\u0440\u0430\u043d"
     ],
     "name:tur_x_preferred":[
         "Anse-Bertrand"
@@ -270,6 +291,9 @@
     ],
     "name:wol_x_preferred":[
         "Anse-Bertrand"
+    ],
+    "name:zho_x_preferred":[
+        "\u6602\u65af\u8d1d\u7279\u6717"
     ],
     "name:zul_x_preferred":[
         "Anse-Bertrand"
@@ -308,7 +332,7 @@
         }
     ],
     "wof:id":890440921,
-    "wof:lastmodified":1566640111,
+    "wof:lastmodified":1690922096,
     "wof:name":"Anse-Bertrand",
     "wof:parent_id":85671209,
     "wof:placetype":"locality",

--- a/data/890/442/739/890442739.geojson
+++ b/data/890/442/739/890442739.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Baillif"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u064a\u0641"
+    ],
     "name:ast_x_preferred":[
         "Baillif"
     ],
@@ -52,6 +55,9 @@
     "name:ces_x_preferred":[
         "Baillif"
     ],
+    "name:che_x_preferred":[
+        "\u0411\u0430\u0439\u0438\u0444"
+    ],
     "name:cos_x_preferred":[
         "Baillif"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Baillif"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b1\u03b3\u03af\u03c6"
     ],
     "name:eng_x_preferred":[
         "Baillif"
@@ -78,6 +87,9 @@
     ],
     "name:fao_x_preferred":[
         "Baillif"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u06cc\u06cc\u0641"
     ],
     "name:fin_x_preferred":[
         "Baillif"
@@ -158,6 +170,9 @@
         "Baillif"
     ],
     "name:lit_x_preferred":[
+        "Baillif"
+    ],
+    "name:lld_x_preferred":[
         "Baillif"
     ],
     "name:ltz_x_preferred":[
@@ -244,6 +259,9 @@
     "name:swe_x_preferred":[
         "Baillif"
     ],
+    "name:tat_x_preferred":[
+        "\u0411\u0430\u0439\u0438\u0444"
+    ],
     "name:tur_x_preferred":[
         "Baillif"
     ],
@@ -273,6 +291,9 @@
     ],
     "name:wol_x_preferred":[
         "Baillif"
+    ],
+    "name:zho_x_preferred":[
+        "\u5df4\u4f0a\u592b"
     ],
     "name:zul_x_preferred":[
         "Baillif"
@@ -309,7 +330,7 @@
         }
     ],
     "wof:id":890442739,
-    "wof:lastmodified":1566640114,
+    "wof:lastmodified":1690922102,
     "wof:name":"Baillif",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/442/799/890442799.geojson
+++ b/data/890/442/799/890442799.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Baie-Mahault"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0649 \u0645\u0627\u0624\u0648"
+    ],
     "name:ast_x_preferred":[
         "Baie-Mahault"
     ],
@@ -55,6 +58,9 @@
     "name:ces_x_preferred":[
         "Baie-Mahault"
     ],
+    "name:che_x_preferred":[
+        "\u0411\u044d-\u041c\u0430\u043e"
+    ],
     "name:cos_x_preferred":[
         "Baie-Mahault"
     ],
@@ -66,6 +72,9 @@
     ],
     "name:deu_x_preferred":[
         "Baie-Mahault"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b1\u03b9-\u039c\u03b1\u03ce"
     ],
     "name:eng_x_preferred":[
         "Baie-Mahault"
@@ -154,6 +163,9 @@
     "name:kon_x_preferred":[
         "Baie-Mahault"
     ],
+    "name:kor_x_preferred":[
+        "\ubca0\ub9c8\uc624"
+    ],
     "name:lat_x_preferred":[
         "Baie-Mahault"
     ],
@@ -167,6 +179,9 @@
         "Baie-Mahault"
     ],
     "name:lit_x_preferred":[
+        "Baie-Mahault"
+    ],
+    "name:lld_x_preferred":[
         "Baie-Mahault"
     ],
     "name:ltz_x_preferred":[
@@ -259,6 +274,9 @@
     "name:swe_x_preferred":[
         "Baie-Mahault"
     ],
+    "name:tat_x_preferred":[
+        "\u0411\u044d-\u041c\u0430\u043e"
+    ],
     "name:tur_x_preferred":[
         "Baie-Mahault"
     ],
@@ -291,6 +309,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62dc-\u99ac\u6b50"
+    ],
+    "name:zho_x_variant":[
+        "\u62dc\u9a6c\u6b27"
     ],
     "name:zul_x_preferred":[
         "Baie-Mahault"
@@ -327,7 +348,7 @@
         }
     ],
     "wof:id":890442799,
-    "wof:lastmodified":1566640114,
+    "wof:lastmodified":1690922101,
     "wof:name":"Baie-Mahault",
     "wof:parent_id":85671209,
     "wof:placetype":"localadmin",

--- a/data/890/453/599/890453599.geojson
+++ b/data/890/453/599/890453599.geojson
@@ -30,6 +30,12 @@
     "name:arg_x_preferred":[
         "Guadalupe"
     ],
+    "name:ary_x_preferred":[
+        "\u063a\u0648\u0627\u062f\u0644\u0648\u0628"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0627\u062f\u0644\u0648\u0628"
+    ],
     "name:ast_x_preferred":[
         "Guadalupe"
     ],
@@ -72,8 +78,17 @@
     "name:che_x_preferred":[
         "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f\u0430"
     ],
+    "name:chr_x_preferred":[
+        "\u13e9\u13d3\u13b7\u13c7"
+    ],
+    "name:ckb_x_preferred":[
+        "\u06af\u0648\u0627\u062f\u0644\u06c6\u067e"
+    ],
     "name:cor_x_preferred":[
         "Gwadeloup"
+    ],
+    "name:cos_x_preferred":[
+        "Guadalupa"
     ],
     "name:cym_x_preferred":[
         "Guadeloupe"
@@ -82,6 +97,9 @@
         "Guadeloupe"
     ],
     "name:deu_x_preferred":[
+        "Guadeloupe"
+    ],
+    "name:diq_x_preferred":[
         "Guadeloupe"
     ],
     "name:div_x_preferred":[
@@ -189,6 +207,9 @@
     "name:jam_x_preferred":[
         "Guadiluup"
     ],
+    "name:jam_x_variant":[
+        "Gwadiluup"
+    ],
     "name:jav_x_preferred":[
         "Guadeloupe"
     ],
@@ -240,8 +261,14 @@
     "name:lit_x_preferred":[
         "Gvadelupa"
     ],
+    "name:lld_x_preferred":[
+        "Guadeloupe"
+    ],
     "name:ltz_x_preferred":[
         "Departement Guadeloupe"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d17\u0d4d\u0d35\u0d3e\u0d26\u0d46\u0d32\u0d42\u0d2a\u0d4d"
     ],
     "name:mar_x_preferred":[
         "\u0917\u094d\u0935\u093e\u0926\u0947\u0932\u094b\u092a"
@@ -251,6 +278,9 @@
     ],
     "name:mlt_x_preferred":[
         "Gwadalup"
+    ],
+    "name:mlt_x_variant":[
+        "Guadeloupe"
     ],
     "name:mrj_x_preferred":[
         "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f\u0430"
@@ -300,6 +330,9 @@
     "name:pap_x_preferred":[
         "Guadelupe"
     ],
+    "name:pcd_x_preferred":[
+        "Guadeloupe"
+    ],
     "name:pms_x_preferred":[
         "Guadalupa"
     ],
@@ -311,6 +344,9 @@
     ],
     "name:por_x_preferred":[
         "Guadalupe"
+    ],
+    "name:pus_x_preferred":[
+        "\u06ab\u0648\u0627\u062f\u0644\u0648\u067e"
     ],
     "name:ron_x_preferred":[
         "Guadelupa"
@@ -326,6 +362,9 @@
     ],
     "name:sco_x_preferred":[
         "Guadeloupe"
+    ],
+    "name:shn_x_preferred":[
+        "\u1075\u1082\u1083\u1038\u1010\u102e\u1087\u101c\u102f\u1015\u103a\u1088"
     ],
     "name:sin_x_preferred":[
         "\u0d9c\u0da9\u0dd9\u0dbd\u0dd4\u0db4\u0dda"
@@ -345,6 +384,9 @@
     "name:sqi_x_preferred":[
         "Guadalupa"
     ],
+    "name:srd_x_preferred":[
+        "Guadalupa"
+    ],
     "name:srp_x_preferred":[
         "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f"
     ],
@@ -360,14 +402,23 @@
     "name:tam_x_preferred":[
         "\u0b95\u0bc1\u0bb5\u0bbe\u0ba4\u0bb2\u0bc2\u0baa\u0bcd\u0baa\u0bc7"
     ],
+    "name:tat_x_preferred":[
+        "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f\u0430"
+    ],
     "name:tel_x_preferred":[
         "\u0c17\u0c4d\u0c35\u0c3e\u0c21\u0c46\u0c32\u0c4b\u0c2a\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f\u0430"
     ],
     "name:tgl_x_preferred":[
         "Guadalupe"
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e31\u0e27\u0e40\u0e14\u0e2d\u0e25\u0e38\u0e1b"
+    ],
+    "name:ton_x_preferred":[
+        "Kuatalupe"
     ],
     "name:tur_x_preferred":[
         "Guadeloupe"
@@ -387,6 +438,9 @@
     "name:uzb_x_preferred":[
         "Gvadelupa"
     ],
+    "name:vec_x_preferred":[
+        "Guadalupa"
+    ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o Guadeloupe"
     ],
@@ -396,8 +450,14 @@
     "name:war_x_preferred":[
         "Guadeloupe"
     ],
+    "name:wln_x_preferred":[
+        "Gwadeloupe"
+    ],
     "name:wol_x_preferred":[
         "Guwaadalup"
+    ],
+    "name:wuu_x_preferred":[
+        "\u74dc\u5fb7\u7f57\u666e"
     ],
     "name:xmf_x_preferred":[
         "\u10d2\u10d5\u10d0\u10d3\u10d4\u10da\u10e3\u10de\u10d0"
@@ -416,6 +476,9 @@
     ],
     "name:zho_x_preferred":[
         "\u74dc\u5fb7\u7f57\u666e"
+    ],
+    "name:zho_x_variant":[
+        "\u74dc\u5fb7\u7f85\u666e"
     ],
     "qs:name":"Guadeloupe",
     "qs:photos_9r":0,
@@ -449,7 +512,7 @@
         }
     ],
     "wof:id":890453599,
-    "wof:lastmodified":1636502859,
+    "wof:lastmodified":1690922099,
     "wof:name":"Guadeloupe",
     "wof:parent_id":85671209,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.