### PR TITLE
gp concordances, placetype local, and more

### DIFF
--- a/data/890/453/599/890453599.geojson
+++ b/data/890/453/599/890453599.geojson
@@ -518,7 +518,7 @@
         }
     ],
     "wof:id":890453599,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Guadeloupe",
     "wof:parent_id":85671209,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.